### PR TITLE
Update README.md: fix "strategy" typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Product Name Screen Shot][product-screenshot]](https://github.com/dcrgll.png)
 
   <p align="center">
-    A new oblique stratergy in the status bar with every click.
+    A new oblique strategy in the status bar with every click.
     <br />
     <a href="https://github.com/dcrgll/vscode-oblique-strategies/issues">Report Bug</a>
     ·


### PR DESCRIPTION
The same type should be fixed in the "about" text 😇:
<img width="1331" alt="Screenshot 2022-11-14 at 07 49 54" src="https://user-images.githubusercontent.com/3862051/201593808-c1cef340-a00b-43ba-b8e5-f72a3cff8a01.png">
